### PR TITLE
feature: supports regex for origin

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,7 +13,8 @@ type Config struct {
 // CORSConfig headers configuration.
 type CORSConfig struct {
 	// AllowedOrigin: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-	AllowedOrigin string `mapstructure:"allowed_origin"`
+	AllowedOrigin         string `mapstructure:"allowed_origin"`
+	AllowedOriginWildcard string `mapstructure:"allowed_origin_wildcard"`
 	// AllowedHeaders: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
 	AllowedHeaders string `mapstructure:"allowed_headers"`
 	// AllowedMethods: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods

--- a/config.go
+++ b/config.go
@@ -13,8 +13,8 @@ type Config struct {
 // CORSConfig headers configuration.
 type CORSConfig struct {
 	// AllowedOrigin: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
-	AllowedOrigin         string `mapstructure:"allowed_origin"`
-	AllowedOriginWildcard string `mapstructure:"allowed_origin_wildcard"`
+	AllowedOrigin      string `mapstructure:"allowed_origin"`
+	AllowedOriginRegex string `mapstructure:"allowed_origin_regex"`
 	// AllowedHeaders: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
 	AllowedHeaders string `mapstructure:"allowed_headers"`
 	// AllowedMethods: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods

--- a/plugin.go
+++ b/plugin.go
@@ -3,6 +3,7 @@ package headers
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/roadrunner-server/errors"
@@ -68,6 +69,13 @@ func (p *Plugin) Init(cfg Configurer) error {
 			// trim all spaces
 			p.cfg.CORS.AllowedOrigin = strings.Trim(p.cfg.CORS.AllowedOrigin, " ")
 			opts.AllowedOrigins = strings.Split(p.cfg.CORS.AllowedOrigin, ",")
+		}
+
+		// if this option is set, the content of `AllowedOrigins` is ignored
+		if p.cfg.CORS.AllowedOriginWildcard != "" {
+			opts.AllowOriginFunc = func(origin string) bool {
+				return regexp.MustCompile(p.cfg.CORS.AllowedOriginWildcard).MatchString(origin)
+			}
 		}
 
 		if p.cfg.CORS.AllowedMethods != "" {

--- a/plugin.go
+++ b/plugin.go
@@ -73,9 +73,9 @@ func (p *Plugin) Init(cfg Configurer) error {
 		}
 
 		// if this option is set, the content of `AllowedOrigins` is ignored
-		if p.cfg.CORS.AllowedOriginWildcard != "" {
+		if p.cfg.CORS.AllowedOriginRegex != "" {
 			var err error
-			p.allowedOriginRegex, err = regexp.Compile(p.cfg.CORS.AllowedOriginWildcard)
+			p.allowedOriginRegex, err = regexp.Compile(p.cfg.CORS.AllowedOriginRegex)
 			if err != nil {
 				return errors.E(op, err)
 			}


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1709

## Description of Changes

Added new configuration property `allowed_origin_wildcard` which allows to use regex in terms of CORS origin. If `allowed_origin_wildcard` is set up then `allowed_origin` is ignored.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for wildcard allowed origins in CORS configuration, providing more flexibility in specifying allowed origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->