### PR TITLE
fix: report plugin coverage instead of the tests module

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,12 +64,12 @@ jobs:
           cd tests
           mkdir ./coverage-ci
 
-          go test -timeout 20m -v -race -cover -tags=debug -failfast -coverpkg=./... -coverprofile=./coverage-ci/headers.out -covermode=atomic ./...
+          go test -timeout 20m -v -race -cover -tags=debug -coverpkg=github.com/roadrunner-server/headers/v6/... -coverprofile=./coverage-ci/headers.out -covermode=atomic ./...
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v7
         with:
-          name: coverage
+          name: coverage-headers
           path: ./tests/coverage-ci/headers.out
 
   codecov:
@@ -80,12 +80,32 @@ jobs:
 
     timeout-minutes: 60
     steps:
+      - name: Check out code
+        uses: actions/checkout@v7
       - name: Download code coverage results
         uses: actions/download-artifact@v8
-      - run: |
+        with:
+          pattern: coverage-*
+          path: coverage
+          merge-multiple: true
+      - name: Prepare coverage report
+        run: |
           echo 'mode: atomic' > summary.txt
-          tail -q -n +2 *.out >> summary.txt
-          sed -i '2,${/roadrunner/!d}' summary.txt
+          tail -q -n +2 coverage/*.out >> summary.txt
+          awk '
+            NR == 1 { print; next }
+            /^github\.com\/roadrunner-server\/headers\/v6\// {
+              sub(/^github\.com\/roadrunner-server\/headers\/v6\//, "", $0)
+              print
+            }
+          ' summary.txt > summary.filtered.txt
+          mv summary.filtered.txt summary.txt
+          # a profile that maps to no plugin source uploads fine and reports 0%
+          blocks=$(($(wc -l < summary.txt) - 1))
+          if [ "$blocks" -lt 10 ]; then
+            echo "::error::coverage summary holds $blocks blocks, the profile does not map to plugin sources"
+            exit 1
+          fi
 
       - name: upload to codecov
         uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>


### PR DESCRIPTION
Coverage has been reporting 0% while the suite has ~600 lines of tests. Three separate defects:

- the e2e step ran `-coverpkg=./...` from inside `tests/`, so it instrumented the tests module, not the plugin
- the codecov job had no `actions/checkout`, so codecov could not map the reported paths onto repo files
- `download-artifact` was called with no `name`/`pattern`, which puts each artifact in its own directory, so the `*.out` glob matched nothing

The last green run on master uploaded 341 bytes. Locally the corrected profile carries 44 blocks.

Scopes coverpkg to `github.com/roadrunner-server/headers/v6/...`, adds the checkout, downloads with an explicit pattern and path, and replaces the `sed` filter with the awk prefix strip that jobs uses. Adds a guard that fails the job when the merged summary holds fewer than 10 blocks — tokenless uploads fail open, which is why this went unnoticed.

Also drops `-failfast`, which hides every failure after the first.
